### PR TITLE
Fix/bureau agents myfab permission

### DIFF
--- a/src/fablabot/cogs/user_management.py
+++ b/src/fablabot/cogs/user_management.py
@@ -481,6 +481,8 @@ class UserManagement(commands.Cog):
         role_names = {role.name for role in member.roles}
         if target_role.name == RoleNames.SBIRE_BUREAU and RoleNames.BUREAU in role_names:
             return True
+        if target_role.name == RoleNames.AGENTS_MYFAB and RoleNames.BUREAU in role_names:
+            return True
         if target_role.name.startswith("Pôle "):
             suffix = target_role.name.split("Pôle ", 1)[1]
             if f"Respo {suffix}" in role_names:

--- a/src/fablabot/helpers/constants.py
+++ b/src/fablabot/helpers/constants.py
@@ -60,6 +60,9 @@ class RoleNames:
     SBIRE_BUREAU = "Sbire Bureau"
     """Office assistant role."""
 
+    AGENTS_MYFAB = "agents MyFab"
+    """MyFab agents role."""
+
     MEMBER_VERIFIED = "Membre ✓"
     """Verified member role."""
 


### PR DESCRIPTION
Allow members with the **Bureau** role to assign the **agents MyFab** role via `/user add_role` and `/user remove_role`.

Changes:

- Added `AGENTS_MYFAB` constant in `RoleNames`

- Added check in `_is_user_responsible_for_pole`, following the same pattern as the existing `Sbire Bureau` rule